### PR TITLE
Fix UTF-8 handling

### DIFF
--- a/makei/build.py
+++ b/makei/build.py
@@ -4,6 +4,7 @@
 # 57XX-XXX
 # (c) Copyright IBM Corp. 2021
 """ The module used to build a project"""
+import sys
 from pathlib import Path
 from tempfile import mkstemp
 from typing import Any, Dict, List, Optional
@@ -127,7 +128,9 @@ class BuildEnv():
             (self.src_dir / ".logs" / "output.log").unlink()
 
 
-        def handle_make_output(line: str):
+        def handle_make_output(lineBytes: bytes):
+            if type(lineBytes) == bytes:
+                line = lineBytes.decode(sys.getdefaultencoding())
             if "Failed to create" in line:
                 self.failed_targets.append(line.split()[-1].split("!")[0])
             if "was created successfully!" in line:

--- a/makei/utils.py
+++ b/makei/utils.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from shutil import move, copymode
 import subprocess
 import sys
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple, Union
 
 from makei.const import DEFAULT_CURLIB, DEFAULT_OBJLIB, FILE_MAX_EXT_LENGTH, FILE_TARGET_MAPPING
 
@@ -188,7 +188,7 @@ def objlib_to_path(lib, object=None) -> str:
         return f"/QSYS.LIB/{lib}.LIB"
 
 
-def print_to_stdout(line: bytes):
+def print_to_stdout(line: Union[str, bytes]):
     """Default stdoutHandler for run_command defined below to write the bytes to the stdout
     """
     if type(line) == str:

--- a/mk/def_rules.mk
+++ b/mk/def_rules.mk
@@ -6,9 +6,9 @@ ifndef COLOR_TTY
 COLOR_TTY := $(shell [ `tput colors` -gt 2 ] && echo true)
 endif
 
-LC_ALL := $(shell echo ${LC_ALL})
+LC_ALL := $(shell  /QOpenSys/pkgs/bin/python3.6  -c "import sys;print(sys.getdefaultencoding())")
 ifndef UTF8_SUPPORT
-	ifneq (,$(findstring UTF-8,$(LC_ALL)))
+	ifneq (,$(findstring utf-8,$(LC_ALL)))
 		UTF8_SUPPORT := true
 	else
 		UTF8_SUPPORT := false

--- a/mk/def_rules.mk
+++ b/mk/def_rules.mk
@@ -6,9 +6,9 @@ ifndef COLOR_TTY
 COLOR_TTY := $(shell [ `tput colors` -gt 2 ] && echo true)
 endif
 
-LC_ALL := $(shell  /QOpenSys/pkgs/bin/python3.6  -c "import sys;print(sys.getdefaultencoding())")
+SYS_ENCODING := $(shell  /QOpenSys/pkgs/bin/python3.6  -c "import sys;print(sys.getdefaultencoding())")
 ifndef UTF8_SUPPORT
-	ifneq (,$(findstring utf-8,$(LC_ALL)))
+	ifneq (,$(findstring utf-8,$(SYS_ENCODING)))
 		UTF8_SUPPORT := true
 	else
 		UTF8_SUPPORT := false


### PR DESCRIPTION
Ran on a system with a PASE CCSID of 1208 but a locale of "C". Ran into the following error:
```
crtrpgmod module(BOBTEST/XML001) srcstmf('/home/JGORZINS/bob-recursive-example/QRPGLESRC/XML001.RPGLE') AUT() DBGVIEW(*ALL) OPTION(*EVENTF) OUTPUT(*PRINT) TEXT('') TGTCCSID(297) TGTRLS()
Traceback (most recent call last):
  File "/QOpenSys/pkgs/bin/makei", line 272, in <module>
    cli()
  File "/QOpenSys/pkgs/bin/makei", line 49, in cli
    args.handle(args)
  File "/QOpenSys/pkgs/bin/makei", line 225, in handle_build
    if build_env.make():
  File "/QOpenSys/pkgs/lib/bob/makei/build.py", line 137, in make
    run_command(self.generate_make_cmd(), handle_make_output)
  File "/QOpenSys/pkgs/lib/bob/makei/utils.py", line 211, in run_command
    stdoutHandler(line.decode('utf-8'))
  File "/QOpenSys/pkgs/lib/bob/makei/build.py", line 135, in handle_make_output
    print_to_stdout(line)
  File "/QOpenSys/pkgs/lib/bob/makei/utils.py", line 194, in print_to_stdout
    print(line, end="")
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2715' in position 10: ordinal not in range(256)
```

`\u2715` is the newly-added X character. 

Changes I made: 
 - changed the UTF-8 check (LC_ALL can be unset but UTF8 is the active CCSID. In fact, this is the default behavior in IBM i 7.4)
 - Reworked the "handle stdout" wrapper to deal with both string and byte contents, and explicitly convert to the default encoding rather than using the generic `print()` function which I believe is problematic in Python 3.9. 
 - Stopped the child process if an error happens when running the subcommand (including the good old `<ctrl>+c`