### PR TITLE
change color-support checks

### DIFF
--- a/makei/utils.py
+++ b/makei/utils.py
@@ -41,7 +41,7 @@ def colored(message: str, color: Colors) -> str:
 
 def support_color():
     """ Detects if the terminal supports color."""
-    return True
+    return sys.stdout.isatty()
 
 
 def read_ibmi_json(path: Path, parent_value: Tuple[str, str]) -> Tuple[str, str]:

--- a/mk/def_rules.mk
+++ b/mk/def_rules.mk
@@ -3,7 +3,7 @@ ERROR_COLOR := \033[31;49;1m
 SUCCESS_COLOR := \033[32;49;1m
 NOCOLOR := \033[0m
 ifndef COLOR_TTY
-COLOR_TTY := $(shell [ `tput colors` -gt 2 ] && echo true)
+COLOR_TTY := $(shell [ -t 1 ] && echo true)
 endif
 
 SYS_ENCODING := $(shell  /QOpenSys/pkgs/bin/python3.6  -c "import sys;print(sys.getdefaultencoding())")


### PR DESCRIPTION
`tput colors` still returns 8, even when output is piped or redirected. 
It also fails to handle the common `vt220` type. 
