### PR TITLE
Fix generation of JSON for template files

### DIFF
--- a/docs/changelogs/changes-v2.md
+++ b/docs/changelogs/changes-v2.md
@@ -12,7 +12,7 @@ Since Bob v2, we require additional packages to be installed on the IBM i as the
 
 [More on the Prerequisites for IBM i](getting-started/prerequisites.md) 
 
-## Installment
+## Installation
 
 In Bob v1, we install `Bob` by putting all the `Bob` files under `/Build/Bob` and point to it in the makefiles we create for the project.
 

--- a/docs/prepare-the-project/convert-source-code.md
+++ b/docs/prepare-the-project/convert-source-code.md
@@ -22,7 +22,7 @@ By default the source files will be encoded as UTF-8, but you may use `-c` optio
 
 Before running this tool, verify that the CCSID of the source physical file is set correctly; a value of 65535 can result in an improper conversion.
 
-[How to use `makei svtsrcpf` command](cli/makei?id=cvtsrcpf)
+[How to use `makei cvtsrcpf` command](cli/makei?id=cvtsrcpf)
 
 There are a couple of other file extension changes that need to be made after converting to stream files.  Any `.RPGLE`  files that are included should be renamed to `.RPGLEINC` so that Bob knows not to compile them.  It is ambiguous for Bob to know whether an ILE source is intended to be compiled into a MODULE, PGM or SRVPGM.  Bob will assume that a MODULE is the default.  If a PGM object is the target using CRTBNDxxx then the file extension should be `PGM.xxx` i.e. PGM.RPGLE for ILE RPG.  If a SRVPGM object is the target then the file extension should be `SRVPGM.xxx` where `xxx` is the ILE language file extension.  See [Supported object types](welcome/features.md?id=supported-object-types) for more discussion of this.
 

--- a/docs/prepare-the-project/project-metadata.md
+++ b/docs/prepare-the-project/project-metadata.md
@@ -7,12 +7,12 @@ The IBM i projects will self-describe how to build themselves as much as possibl
 ## Technical Assumptions
 
 * Metadata will be stored in JSON because:
-  * JSON is the most popular persistence mechanism because it is lightweight and easily derstood by both humans and computers
+  * JSON is the most popular persistence mechanism because it is lightweight and easily understood by both humans and computers
   * JSON is native any node.js based platform and has readily available tooling in all others
 * All third parties should generate/use the common metadata. Third-parties can store additional metadata in additional JSON within the same file.
 * Places to store information
-  * Project level json – in the root directory of the project - iproj.json (analogous to package.json) – could be used for storing name of project, version information, dependencies, git repo, description, license  AND IBM i attributes like target object library, target CCSID, LIBL, initial CL and include directories
+  * Project level JSON – in the root directory of the project - iproj.json (analogous to package.json) – could be used for storing name of project, version information, dependencies, git repo, description, license  AND IBM i attributes like target object library, target CCSID, LIBL, initial CL and include directories
   (part of the vision to make an IBM i package manager that is still in progress)
-  * Directory level json - .ibmi.json in each directory allows overriding of target library and CCSID in  for that directory and its sub-directories.
+  * Directory level JSON - .ibmi.json in each directory allows overriding of target library and CCSID in  for that directory and its sub-directories.
   * Comments  in the code itself
 

--- a/makei/ibmi_json.py
+++ b/makei/ibmi_json.py
@@ -58,11 +58,10 @@ class IBMiJson:
             build["objlib"] = self.build["objlib"]
 
         if len(build.keys()) > 0:
-            ibmi = {
+            return  {
                 "version": self.version,
                 "build": build
             }
-            return json.dumps(ibmi, indent=4)
         else:
             return None
 

--- a/makei/init_project.py
+++ b/makei/init_project.py
@@ -82,7 +82,7 @@ class ProjSpec():
 
     def generate_iproj_json(self) -> str:
         """ Generates an iProj.json template"""
-        iprojJson = IProjJson(self.description,
+        iproj_json = IProjJson(self.description,
                                 self.version,
                                 self.license,
                                 self.repository,
@@ -93,7 +93,7 @@ class ProjSpec():
                                 self.post_usr_libl,
                                 self.set_ibm_i_env_cmd,
                                 self.tgt_ccsid)
-        return json.dumps(iprojJson.__dict__, indent=4)
+        return json.dumps(iproj_json.__dict__(), indent=4)
 
     def generate_ibmi_json(self) -> Optional[str]:
         """ Returns a string representation of the .ibmi.json file of current project"""
@@ -102,7 +102,7 @@ class ProjSpec():
             "tgt_ccsid": self.tgt_ccsid,
             "objlib": self.objlib,
         })
-        return json.dumps(ibmijson.__dict__, indent=4)
+        return json.dumps(ibmijson.__dict__(), indent=4)
 
     def generate_rules_mk(self) -> str:
         """ Generates a Rules.mk template"""


### PR DESCRIPTION
The serialisation of objects through the __dict__ methods was not working. This change makes sure the actual dictionaries are passed to json.dumps rather than the class methods. Fixes #169.