### PR TITLE
Add CVTSRCPF option '-l/--tolower'

### DIFF
--- a/src/makei/cli/makei_entry.py
+++ b/src/makei/cli/makei_entry.py
@@ -169,6 +169,14 @@ def add_cvtsrcpf_parser(subparsers: argparse.ArgumentParser):
         type=str
     )
 
+    cvtsrcpf_parser.add_argument(
+        "-l",
+        "--tolower",
+        help='The generated source file name will be in lowercase.',
+        action='store_true'
+    )
+
+    cvtsrcpf_parser.set_defaults(tolower=False)
     cvtsrcpf_parser.set_defaults(handle=handle_cvtsrcpf)
 
 
@@ -250,7 +258,7 @@ def handle_cvtsrcpf(args):
     """
     Processing the cvtsrcpf command
     """
-    CvtSrcPf(args.file, args.library, args.ccsid).run()
+    CvtSrcPf(args.file, args.library, args.tolower, args.ccsid).run()
 
 
 def get_override_vars(args):

--- a/src/makei/cvtsrcpf.py
+++ b/src/makei/cvtsrcpf.py
@@ -18,9 +18,12 @@ class CvtSrcPf:
     srcfile: str
     save_path: Path
     default_ccsid: Optional[str]
+    tolower: bool
     ibmi_json_path: Optional[Path]
 
-    def __init__(self, srcfile: str, lib: str, default_ccsid: str = None, save_path: Path = Path.cwd()) -> None:
+    def __init__(
+        self, srcfile: str, lib: str, tolower: bool, default_ccsid: str = None, save_path: Path = Path.cwd()
+    ) -> None:
         self.job = IBMJob()
 
         self.lib = lib
@@ -31,6 +34,7 @@ class CvtSrcPf:
         else:
             self.default_ccsid = None
 
+        self.tolower = tolower
         self.ibmi_json_path = save_path / ".ibmi.json"
 
     def run(self) -> int:
@@ -48,13 +52,13 @@ class CvtSrcPf:
         print(f"{len(src_mbrs)} source members found.")
         cvt_count = 0
         for src_mbr in src_mbrs:
-            if self._cvr_src_mbr(src_mbr, srcpath):
+            if self._cvr_src_mbr(src_mbr, srcpath, self.tolower):
                 cvt_count += 1
         if self.ibmi_json_path:
             create_ibmi_json(self.ibmi_json_path, tgt_ccsid=self.default_ccsid)
         return cvt_count
 
-    def _cvr_src_mbr(self, src_mbr, srcpath) -> bool:
+    def _cvr_src_mbr(self, src_mbr, srcpath, tolower: bool) -> bool:
         """Convert the source member
         """
         src_mbr_name = src_mbr[0]
@@ -62,6 +66,8 @@ class CvtSrcPf:
         if src_mbr_ext == ".src":
             src_mbr_ext = ".pf"
         dst_mbr_name = f"{src_mbr_name}.{src_mbr_ext}"
+        if tolower:
+            dst_mbr_name = dst_mbr_name.lower()
         dst_mbr_path = self.save_path / dst_mbr_name
         dups = 0
         while dst_mbr_path.exists():


### PR DESCRIPTION
Source members in the QSYS filesystem are stored in uppercase names and so far the `cvtsrcpf` command in BOB has converted the members to streamfiles keeping the uppercase names.

Having source files in uppercase names is not the normal behavior on other platforms - and some developers (me and maybe others 😄) don't like all uppercase and consider this "screaming".

I have added an option to the `cvtsrcpf` function of `makei` to allow the converted source file names to be changed into lowercase. I tested the `makei` rules with target and source in upper and lower case, and this testing does not indicate any problems with source files names in lowercase. Please correct me if I'm wrong. 😄
