### PR TITLE
By requiring 3.9 versions of python and the db2 interface, avoid mism…

### DIFF
--- a/tools/release/bob.spec.template
+++ b/tools/release/bob.spec.template
@@ -15,8 +15,8 @@ Requires: sed-gnu >= 4.4-1
 Requires: grep-gnu >= 3.0-2
 Requires: gawk >= 4.1.4-2
 Requires: make-gnu >= 4.2-2
-Requires: python3 >= 3.6
-Requires: python3-ibm_db >= 2.0.5.12
+Requires: python39 >= 3.9.18
+Requires: python39-ibm_db >= 2.0.5.12
 
 Source0: https://github.com/IBM/ibmi-bob/archive/refs/tags/v%{version}.tar.gz
 


### PR DESCRIPTION
Previous requirement of python3 allowed 3.9
but then you need to use the `python39-ibm_db` module to provide the interface to DB2 and the mismatch led to the described error.