### PR TITLE
Support CMD as file extension as well as CMDSRC

### DIFF
--- a/docs/welcome/features.md
+++ b/docs/welcome/features.md
@@ -27,7 +27,7 @@ These IBM i source types can be compiled directly from the IFS
 
 | Object Type | File Extension                                                        |
 | :---------- | :-------------------------------------------------------------------- |
-| *CMD        | .CMDSRC                                                               |
+| *CMD        | .CMD                                                                  |
 | *MODULE     | .RPGLE, .CLLE, .C, .SQLC, .CPP, .SQLCPP, .SQLRPGLE, .CBLLE, .SQLCBLLE |
 | *PGM        | .PGM.RPGLE, .PGM.SQLRPGLE, .PGM.C, .PGM.CBLLE, .PGM.SQLCBLLE          |
 | *SRVPGM     | .BND                                                                  |
@@ -44,7 +44,7 @@ These older IBM i source types are compiled directly from the IFS using the CRTF
 | Object Type | File Extension                      |
 | :---------- | :---------------------------------- |
 | *FILE       | .DSPF, .LF, .PF, .PRTF              |
-| *MENU       | .MENU                               |
+| *MENU       | .MENUSRC                            |
 | *MODULE     | .CLLE                               |
 | *PGM        | .RPG, .PGM.CLLE                     |
 | *PNLGRP     | .PNLGRPSRC                          |

--- a/src/makei/const.py
+++ b/src/makei/const.py
@@ -40,6 +40,7 @@ FILE_TARGETGROUPS_MAPPING = {
     "PGM.C": "PGM",
     "PGM.SQLCBLLE": "PGM",
     "CMDSRC": "CMD",
+    "CMD": "CMD",
     "DSPF": "DSPF",
     "LF": "LF",
     "PF": "PF",
@@ -105,6 +106,7 @@ FILE_TARGET_MAPPING = {
     "PGM.CBLLE": "PGM",
     "PGM.SQLCBLLE": "PGM",
     "CMDSRC": "CMD",
+    "CMD": "CMD",
     "DSPF": "FILE",
     "LF": "FILE",
     "PF": "FILE",
@@ -153,7 +155,7 @@ MEMBER_TEXT_LINES = 15
 _start_column = 7
 _end_column = 72
 C_STYLE_COMMENTS = (
-    {"CMDSRC", "C", "CPP", "CLLE", "CLP", "SQLC", "SQLCPP", "PGM.C", "PGM.CLLE", "BND",
+    {"CMD","CMDSRC", "C", "CPP", "CLLE", "CLP", "SQLC", "SQLCPP", "PGM.C", "PGM.CLLE", "BND",
         "ILESRVPGM", "BNDDIR", "DTAARA", "SYSTRG", "MSGF"},
     {
         "style_type": "C",

--- a/src/mk/def_rules.mk
+++ b/src/mk/def_rules.mk
@@ -915,7 +915,21 @@ define CMDSRC_TO_CMD_RECIPE =
 	@$(PRESETUP) \
 	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" "$(PRECMD)" "$(POSTCMD)" "$(notdir $@)" "$<" $(logFile)> $(logFile) 2>&1 && $(call logSuccess,$@) || $(call logFail,$@);
 endef
-
+define CMD_TO_CMD_RECIPE = 
+	$(eval AUT = $(CMD_AUT))
+	$(eval ALLOW = $(CMD_ALLOW))
+	$(eval HLPID = $(CMD_HLPID))
+	$(eval HLPPNLGRP = $(CMD_HLPPNLGRP))
+    $(eval PGM = $(OBJLIB)/$(CMD_PGM))
+	$(eval PMTFILE = $(CMD_PMTFILE))
+	$(eval VLDCKR = $(CMD_VLDCKR))
+	$(eval d = $($@_d))
+	@$(call echo_cmd,"=== Creating command [$(notdir $<)] in $(OBJLIB)")
+	$(eval crtcmd := CRTCMD CMD($(OBJLIB)/$(basename $(@F))) srcstmf('$<') $(CRTCMDFLAGS))
+	$(eval logFile := $(LOGPATH)/$(notdir $(basename $<)).splf)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" "$(PRECMD)" "$(POSTCMD)" "$(notdir $@)" "$<" $(logFile)> $(logFile) 2>&1 && $(call logSuccess,$@) || $(call logFail,$@);
+endef
 
 
 


### PR DESCRIPTION
User can use CMD or CMDSRC as file extenstions for the pseudo-source to create CMD objects

Fixes #301 