### PR TITLE
Fix `ValueError` exception during migration

### DIFF
--- a/src/makei/cvtsrcpf.py
+++ b/src/makei/cvtsrcpf.py
@@ -206,8 +206,9 @@ def _get_attr(filepath: str, defaultCcsid: str):
         raise Exception(f"Unable to access '{filepath}' make sure file exists and that the user has permissions to it")
     else:
         for attr in output.split("\n"):
-            [key, value] = attr.split("=")
-            attrs[key] = value
+            if "=" in attr:
+                [key, value] = attr.split("=")
+                attrs[key] = value
     return attrs
 
 


### PR DESCRIPTION
Fixes this `ValueError` exception:
![image](https://github.com/user-attachments/assets/f607ef33-4c0c-4790-8528-fe42218c1bc1)
