### PR TITLE
Added variable expansion for dependencies

### DIFF
--- a/src/makei/rules_mk.py
+++ b/src/makei/rules_mk.py
@@ -326,6 +326,11 @@ class RulesMk:
 
         # Create all the rules for the wildcard rule declaration
         for target_ext, source_ext, dependencies in wildcard_targets:
+            # Expand any variables in the dependencies
+            expanded_deps = dependencies
+            for var_name, var_value in rules_mk_variables.items():
+                expanded_deps = expanded_deps.replace(f"$({var_name})", var_value)
+            #target specific variable assignmnet(expansion)
             for filename in os.listdir(dir_path):
                 recipe_str = ''
                 filename_split = filename.split('.', 1)
@@ -334,7 +339,7 @@ class RulesMk:
                     target_object = (filename_split[0] + "." + target_ext).upper()
                     if target_object not in targets:
                         recipe_str = (
-                            target_object + ": " + filename_split[0] + "." + source_ext + " " + dependencies
+                            target_object + ": " + filename_split[0] + "." + source_ext + " " + expanded_deps
                         ).strip() + '\n'
                         rules.append(MKRule.from_str(recipe_str, containing_dir, include_dirs))
                         targets.append(target_object)

--- a/tests/unit/test_rules_mk.py
+++ b/tests/unit/test_rules_mk.py
@@ -78,12 +78,12 @@ AB2001.B.MODULE: TGTRLS :=*PRV
     assert rules_mk.rules[3].variables == ['TEXT := hardcoded for all mod', 'TGTVER=V7R5',
                                            'private TEXT := foo is better', 'TGTVER := V7R2']
     assert rules_mk.rules[3].commands == []
-    assert rules_mk.rules[3].dependencies == ['$(HEADER).rpgleinc']
+    assert rules_mk.rules[3].dependencies == ['some.rpgleinc']
     assert rules_mk.rules[3].include_dirs == []
     assert rules_mk.rules[3].target == 'FOO.MODULE'
     assert rules_mk.rules[3].source_file == '$(d)/foo.rpgle'
     assert str(rules_mk.rules[3]) == '''FOO.MODULE_SRC=$(d)/foo.rpgle
-FOO.MODULE_DEP=$(HEADER).rpgleinc
+FOO.MODULE_DEP=some.rpgleinc
 FOO.MODULE_RECIPE=RPGLE_TO_MODULE_RECIPE
 FOO.MODULE: TEXT := hardcoded for all mod
 FOO.MODULE: TGTVER=V7R5
@@ -108,7 +108,7 @@ AB2001.B.MODULE_RECIPE=RPGLE_TO_MODULE_RECIPE
 AB2001.B.MODULE: TEXT := hardcoded for all mod
 AB2001.B.MODULE: TGTRLS :=*PRV
 FOO.MODULE_SRC=$(d)/foo.rpgle
-FOO.MODULE_DEP=$(HEADER).rpgleinc
+FOO.MODULE_DEP=some.rpgleinc
 FOO.MODULE_RECIPE=RPGLE_TO_MODULE_RECIPE
 FOO.MODULE: TEXT := hardcoded for all mod
 FOO.MODULE: TGTVER=V7R5


### PR DESCRIPTION
Made changes in file Rules_mk.py by adding lines for expanding dependencies hence resolved *** multiple target patterns. *** error while creating the module for the wildcard scenario
<img width="1030" height="616" alt="image" src="https://github.com/user-attachments/assets/756f6521-9518-4c71-9901-93c5286f832c" />

For test case
<img width="1018" height="319" alt="image" src="https://github.com/user-attachments/assets/477e24d8-f627-44bb-8a51-5fe863435bc0" />

