### PR TITLE
Fixed the "*** empty variable name" error in def_rules.mk.

### DIFF
--- a/src/mk/def_rules.mk
+++ b/src/mk/def_rules.mk
@@ -1618,7 +1618,7 @@ test:
 	echo "PROJECTDIR:		$(PROJECTDIR)";
 
 # Definition of variable ${\n} containing just new-line character
-define \n
+define \\n
 
 
 endef


### PR DESCRIPTION
The Purpose of the \n Variable:

This is not about Windows vs Linux file systems. The \n variable is a Make programming technique to create a variable that contains a literal newline character. This is useful in Make for:

Multi-line string construction - Building commands or text that span multiple lines Dynamic recipe generation - Creating complex shell commands with proper line breaks Text formatting - When you need to output formatted text with newlines The variable is defined using Make's define directive with two blank lines between define and endef. This captures the newline character itself as the variable's value. You would reference it as $(\n) or ${\n} in makefiles.

The Bug:
The original code define \n was incorrect because Make interpreted \n as an escape sequence (newline), leaving an empty variable name, hence the error "*** empty variable name".

The Fix:
Changed to define \\n so the backslash is escaped, making \n the actual variable name rather than being interpreted as a newline escape sequence.

Note: This variable appears to be defined but not currently used in the codebase - it may be reserved for future use or left over from refactoring.