### PR TITLE
Fixed the FileNotFoundError in test_build_env.py by updating the _pos…

### DIFF
--- a/src/makei/build.py
+++ b/src/makei/build.py
@@ -199,7 +199,7 @@ COLOR_TTY := {'true' if self.color else 'false'}
 
     def _post_make(self):
         for tmp_file in self.tmp_files:
-            tmp_file.unlink()
+            tmp_file.unlink(missing_ok=True)
         print(colored("Objects:            ", Colors.BOLD), colored(f"{len(self.failed_targets)} failed", Colors.FAIL),
               colored(f"{len(self.success_targets)} succeed", Colors.OKGREEN),
               f"{len(self.success_targets) + len(self.failed_targets)} total")


### PR DESCRIPTION
…t_make() method to use unlink(missing_ok=True) instead of unlink().

The issue occurred because the test was calling _post_make() in a finally block without actually running the build process, so the temporary files in self.tmp_files didn't exist. The missing_ok=True parameter (available in Python 3.8+) allows the unlink operation to succeed even if the file doesn't exist.